### PR TITLE
Syntax highlighting for mix.lock files

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
             "id": "elixir",
             "aliases": ["Elixir", "elixir"],
             "extensions": [".ex",".exs"],
+            "filenames": ["mix.lock"],
             "configuration": "./elixir-language-configuration.json"
         },
         {


### PR DESCRIPTION
This is a really simple PR which only instructs VSCode to apply Elixir syntax highlighting to `mix.lock` files. Syntax highlighting can help a lot when inspecting `mix.lock` files for debugging dependencies.